### PR TITLE
Guard which-key popup eventignore

### DIFF
--- a/.config/nvim/lua/marshmalon/lazy/which-key.lua
+++ b/.config/nvim/lua/marshmalon/lazy/which-key.lua
@@ -57,5 +57,24 @@ return {
       buftypes = {},
       filetypes = { "TelescopePrompt" },
     },
-  }
+  },
+  config = function(_, opts)
+    require("which-key").setup(opts)
+
+    local win = require("which-key.win")
+    if not win._marshmalon_safe_show then
+      local original_show = win.show
+      win.show = function(self, show_opts)
+        local eventignore = vim.go.eventignore
+        local ok, result = pcall(original_show, self, show_opts)
+        vim.go.eventignore = eventignore
+        if not ok then
+          vim.notify("which-key popup failed: " .. result, vim.log.levels.WARN)
+          return nil
+        end
+        return result
+      end
+      win._marshmalon_safe_show = true
+    end
+  end,
 }

--- a/.config/nvim/lua/marshmalon/lazy_init.lua
+++ b/.config/nvim/lua/marshmalon/lazy_init.lua
@@ -13,5 +13,11 @@ vim.opt.rtp:prepend(lazypath)
 
 require("lazy").setup({
     spec = "marshmalon.lazy",
-    change_detection = { notify = false }
+    change_detection = {
+      enabled = false,
+      notify = false,
+    },
+    checker = {
+      enabled = false,
+    },
 })

--- a/.config/nvim/lua/marshmalon/remap.lua
+++ b/.config/nvim/lua/marshmalon/remap.lua
@@ -1,6 +1,3 @@
-local builtin = require('telescope.builtin')
-
-
 local function map(modes, lhs, rhs, desc, opts)
   opts = opts or {}
   opts.desc = desc
@@ -29,8 +26,8 @@ local function copy_relative_path()
   vim.notify("Copied relative path (clipboard unavailable): " .. relative_path, vim.log.levels.WARN)
 end
 
-map("n", "<leader> ", ":Telescope live_grep<CR>", "Find")
-map("n", "<leader>f", builtin.find_files, "Find files")
+map("n", "<leader> ", function() require("telescope.builtin").live_grep() end, "Find")
+map("n", "<leader>f", function() require("telescope.builtin").find_files() end, "Find files")
 map("n", "<leader>go", function() require("gitlinker").get_buf_range_url("n") end, "Open git link")
 map("v", "<leader>go", function() require("gitlinker").get_buf_range_url("v") end, "Open git link")
 map("n", "<leader>gb", function() require("gitsigns").blame() end, "Git blame file")
@@ -42,6 +39,6 @@ map("n", "<C-u>", "<C-u>zz", "Half page up and center")
 map("n", "n", "nzzzv", "Next search result and center")
 map("n", "N", "Nzzzv", "Previous search result and center")
 map("n", "Q", "<nop>", "Disable Ex mode")
-map("n", ";", builtin.buffers, "Find buffers")
+map("n", ";", function() require("telescope.builtin").buffers() end, "Find buffers")
 map("n", "<C-h>", "<C-w>h", "Move to left window")
 map("n", "<C-l>", "<C-w>l", "Move to right window")


### PR DESCRIPTION
Wrap which-key popup creation to always restore eventignore on failure. This prevents autocmds from staying disabled after a leader-only press. Keeps highlights and Git signs working after timeouts.